### PR TITLE
BufferWhileBy: emit empty array when primary source finished first (#128)

### DIFF
--- a/docs-src/descriptions/two-sources.jade
+++ b/docs-src/descriptions/two-sources.jade
@@ -164,7 +164,8 @@ p.
   #[tt flushOnChange] (by default #[tt false]). If #[tt flushOnEnd] set to
   #[tt false], the buffer won't be flushed when the main observable ends.
   If #[tt flushOnChange] set to #[tt true], the buffer will be flushed when the
-  controlling observable emits #[tt false].
+  controlling observable emits #[tt false]. If #[b obs] finished before #[b otherObs]
+  emitted any value, emits empty array and ends.
 
 
 pre.javascript(title='example').
@@ -221,4 +222,3 @@ pre(title='events in time').
 
   result:  f---t-f--t-f--t-fX
 div
-

--- a/docs-src/descriptions/two-sources.jade
+++ b/docs-src/descriptions/two-sources.jade
@@ -222,3 +222,4 @@ pre(title='events in time').
 
   result:  f---t-f--t-f--t-fX
 div
+

--- a/docs-src/descriptions/two-sources.jade
+++ b/docs-src/descriptions/two-sources.jade
@@ -164,8 +164,8 @@ p.
   #[tt flushOnChange] (by default #[tt false]) and #[tt emitEmpty] (by default #[tt false]). 
   If #[tt flushOnEnd] set to #[tt false], the buffer won't be flushed when the main observable ends.
   If #[tt flushOnChange] set to #[tt true], the buffer will be flushed when the
-  controlling observable emits #[tt false]. If #[tt emitEmpty] set to #[tt true] and 
-  #[b obs] finished before #[b otherObs] emitted any value, it emits empty array before ending.
+  controlling observable emits #[tt false]. If #[tt emitEmpty] set to #[tt true],
+  it will emit empty array when buffer supposed to be flushed, but it's empty.
 
 
 pre.javascript(title='example').

--- a/docs-src/descriptions/two-sources.jade
+++ b/docs-src/descriptions/two-sources.jade
@@ -160,12 +160,12 @@ div
   otherwise flushes the buffer (with the new value included).
 
 p.
-  It supports two #[b options]: #[tt flushOnEnd] (by default #[tt true]) and
-  #[tt flushOnChange] (by default #[tt false]). If #[tt flushOnEnd] set to
-  #[tt false], the buffer won't be flushed when the main observable ends.
+  It supports three #[b options]: #[tt flushOnEnd] (by default #[tt true]),
+  #[tt flushOnChange] (by default #[tt false]) and #[tt emitEmpty] (by default #[tt false]). 
+  If #[tt flushOnEnd] set to #[tt false], the buffer won't be flushed when the main observable ends.
   If #[tt flushOnChange] set to #[tt true], the buffer will be flushed when the
-  controlling observable emits #[tt false]. If #[b obs] finished before #[b otherObs]
-  emitted any value, emits empty array and ends.
+  controlling observable emits #[tt false]. If #[tt emitEmpty] set to #[tt true] and 
+  #[b obs] finished before #[b otherObs] emitted any value, it emits empty array before ending.
 
 
 pre.javascript(title='example').
@@ -222,4 +222,3 @@ pre(title='events in time').
 
   result:  f---t-f--t-f--t-fX
 div
-

--- a/src/two-sources/buffer-while-by.js
+++ b/src/two-sources/buffer-while-by.js
@@ -15,7 +15,7 @@ const mixin = {
   },
 
   _flush() {
-    if (this._buff !== null && this._buff.length !== 0) {
+    if (this._buff !== null) {
       this._emitValue(this._buff);
       this._buff = [];
     }

--- a/src/two-sources/buffer-while-by.js
+++ b/src/two-sources/buffer-while-by.js
@@ -4,8 +4,9 @@ const {NOTHING} = require('../constants');
 
 const mixin = {
 
-  _init({flushOnEnd = true, flushOnChange = false} = {}) {
+  _init({flushOnEnd = true, flushOnChange = false, emitEmpty = false} = {}) {
     this._buff = [];
+    this._emitEmpty = emitEmpty;
     this._flushOnEnd = flushOnEnd;
     this._flushOnChange = flushOnChange;
   },
@@ -15,7 +16,7 @@ const mixin = {
   },
 
   _flush() {
-    if (this._buff !== null) {
+    if ((this._buff !== null) && (this._emitEmpty || (this._buff.length > 0))) {
       this._emitValue(this._buff);
       this._buff = [];
     }

--- a/test/specs/buffer-while-by.coffee
+++ b/test/specs/buffer-while-by.coffee
@@ -20,11 +20,17 @@ describe 'bufferWhileBy', ->
       b = prop()
       expect(a.bufferWhileBy(b)).toActivate(a, b)
 
-    it 'should flush empty buffer and then end when primary ends', ->
-      expect(send(stream(), ['<end>']).bufferWhileBy(stream())).toEmit [{current: []}, '<end:current>']
+    it 'should end when primary ends (w/o {emitEmpty: true})', ->
+      expect(send(stream(), ['<end>']).bufferWhileBy(stream())).toEmit ['<end:current>']
       a = stream()
       b = stream()
-      expect(a.bufferWhileBy(b)).toEmit [[], '<end>'], -> send(a, ['<end>'])
+      expect(a.bufferWhileBy(b)).toEmit ['<end>'], -> send(a, ['<end>'])
+
+    it 'should flush empty buffer and then end when primary ends (w/ {emitEmpty: true})', ->
+      expect(send(stream(), ['<end>']).bufferWhileBy(stream(), {emitEmpty: true})).toEmit [{current: []}, '<end:current>']
+      a = stream()
+      b = stream()
+      expect(a.bufferWhileBy(b, {emitEmpty: true})).toEmit [[], '<end>'], -> send(a, ['<end>'])
 
     it 'should flush buffer on end', ->
       expect(send(prop(), [1, '<end>']).bufferWhileBy(stream())).toEmit [{current: [1]}, '<end:current>']
@@ -161,4 +167,3 @@ describe 'bufferWhileBy', ->
       a = send(prop(), [1])
       b = send(prop(), [true])
       expect(a.bufferWhileBy(b)).toEmit []
-

--- a/test/specs/buffer-while-by.coffee
+++ b/test/specs/buffer-while-by.coffee
@@ -32,6 +32,12 @@ describe 'bufferWhileBy', ->
       b = stream()
       expect(a.bufferWhileBy(b, {emitEmpty: true})).toEmit [[], '<end>'], -> send(a, ['<end>'])
 
+    it 'should flush empty buffer and then end when primary ends (w/ {flushOnChange: true, emitEmpty: true})', ->
+      expect(send(stream(), ['<end>']).bufferWhileBy(stream(), {flushOnChange: true, emitEmpty: true})).toEmit [{current: []}, '<end:current>']
+      a = stream()
+      b = stream()
+      expect(a.bufferWhileBy(b, {flushOnChange: true, emitEmpty: true})).toEmit [[], '<end>'], -> send(a, ['<end>'])
+
     it 'should flush buffer on end', ->
       expect(send(prop(), [1, '<end>']).bufferWhileBy(stream())).toEmit [{current: [1]}, '<end:current>']
       a = stream()

--- a/test/specs/buffer-while-by.coffee
+++ b/test/specs/buffer-while-by.coffee
@@ -32,11 +32,11 @@ describe 'bufferWhileBy', ->
       b = stream()
       expect(a.bufferWhileBy(b, {emitEmpty: true})).toEmit [[], '<end>'], -> send(a, ['<end>'])
 
-    it 'should flush empty buffer and then end when primary ends (w/ {flushOnChange: true, emitEmpty: true})', ->
-      expect(send(stream(), ['<end>']).bufferWhileBy(stream(), {flushOnChange: true, emitEmpty: true})).toEmit [{current: []}, '<end:current>']
+    it 'should flush empty buffer and then end when secondary ends (w/ {flushOnChange: true, emitEmpty: true})', ->
+      expect(stream().bufferWhileBy(send(prop(), [true, false]), {flushOnChange: true, emitEmpty: true})).toEmit [{current: []}]
       a = stream()
       b = stream()
-      expect(a.bufferWhileBy(b, {flushOnChange: true, emitEmpty: true})).toEmit [[], '<end>'], -> send(a, ['<end>'])
+      expect(a.bufferWhileBy(b, {flushOnChange: true, emitEmpty: true})).toEmit [[]], -> send(b, [true, false])
 
     it 'should flush buffer on end', ->
       expect(send(prop(), [1, '<end>']).bufferWhileBy(stream())).toEmit [{current: [1]}, '<end:current>']

--- a/test/specs/buffer-while-by.coffee
+++ b/test/specs/buffer-while-by.coffee
@@ -161,3 +161,4 @@ describe 'bufferWhileBy', ->
       a = send(prop(), [1])
       b = send(prop(), [true])
       expect(a.bufferWhileBy(b)).toEmit []
+

--- a/test/specs/buffer-while-by.coffee
+++ b/test/specs/buffer-while-by.coffee
@@ -32,7 +32,7 @@ describe 'bufferWhileBy', ->
       b = stream()
       expect(a.bufferWhileBy(b, {emitEmpty: true})).toEmit [[], '<end>'], -> send(a, ['<end>'])
 
-    it 'should flush empty buffer and then end when secondary ends (w/ {flushOnChange: true, emitEmpty: true})', ->
+    it 'should flush empty buffer when secondary emits false (w/ {flushOnChange: true, emitEmpty: true})', ->
       expect(stream().bufferWhileBy(send(prop(), [true, false]), {flushOnChange: true, emitEmpty: true})).toEmit [{current: []}]
       a = stream()
       b = stream()

--- a/test/specs/buffer-while-by.coffee
+++ b/test/specs/buffer-while-by.coffee
@@ -20,11 +20,11 @@ describe 'bufferWhileBy', ->
       b = prop()
       expect(a.bufferWhileBy(b)).toActivate(a, b)
 
-    it 'should end when primary ends', ->
-      expect(send(stream(), ['<end>']).bufferWhileBy(stream())).toEmit ['<end:current>']
+    it 'should flush empty buffer and then end when primary ends', ->
+      expect(send(stream(), ['<end>']).bufferWhileBy(stream())).toEmit [{current: []}, '<end:current>']
       a = stream()
       b = stream()
-      expect(a.bufferWhileBy(b)).toEmit ['<end>'], -> send(a, ['<end>'])
+      expect(a.bufferWhileBy(b)).toEmit [[], '<end>'], -> send(a, ['<end>'])
 
     it 'should flush buffer on end', ->
       expect(send(prop(), [1, '<end>']).bufferWhileBy(stream())).toEmit [{current: [1]}, '<end:current>']
@@ -161,4 +161,3 @@ describe 'bufferWhileBy', ->
       a = send(prop(), [1])
       b = send(prop(), [true])
       expect(a.bufferWhileBy(b)).toEmit []
-

--- a/test/specs/buffer-while-by.coffee
+++ b/test/specs/buffer-while-by.coffee
@@ -33,7 +33,7 @@ describe 'bufferWhileBy', ->
       expect(a.bufferWhileBy(b, {emitEmpty: true})).toEmit [[], '<end>'], -> send(a, ['<end>'])
 
     it 'should flush empty buffer when secondary emits false (w/ {flushOnChange: true, emitEmpty: true})', ->
-      expect(stream().bufferWhileBy(send(prop(), [true, false]), {flushOnChange: true, emitEmpty: true})).toEmit [{current: []}]
+      expect(stream().bufferWhileBy(send(prop(), [false]), {flushOnChange: true, emitEmpty: true})).toEmit [{current: []}]
       a = stream()
       b = stream()
       expect(a.bufferWhileBy(b, {flushOnChange: true, emitEmpty: true})).toEmit [[]], -> send(b, [true, false])


### PR DESCRIPTION
See #128 