### PR TITLE
Fix #134

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "grunt-webpack": "1.0.11",
     "inquirer": "0.9.0",
     "jasmine-node": "1.14.5",
+    "js-combinatorics": "0.5.0",
     "load-grunt-tasks": "3.2.0",
     "node-libs-browser": "0.5.2",
     "rx": "3.1.0",

--- a/src/one-source/delay.js
+++ b/src/one-source/delay.js
@@ -1,11 +1,20 @@
 const {createStream, createProperty} = require('../patterns/one-source');
 
+const END_MARKER = {};
+
 const mixin = {
 
   _init({wait}) {
     this._wait = Math.max(0, wait);
     this._buff = [];
-    this._$shiftBuff = () => this._emitValue(this._buff.shift());
+    this._$shiftBuff = () => {
+      const value = this._buff.shift();
+      if (value === END_MARKER) {
+        this._emitEnd();
+      } else {
+        this._emitValue(value);
+      }
+    };
   },
 
   _free() {
@@ -26,7 +35,8 @@ const mixin = {
     if (this._activating) {
       this._emitEnd();
     } else {
-      setTimeout(() => this._emitEnd(), this._wait);
+      this._buff.push(END_MARKER);
+      setTimeout(this._$shiftBuff, this._wait);
     }
   }
 

--- a/test/specs/delay.coffee
+++ b/test/specs/delay.coffee
@@ -1,5 +1,5 @@
 {stream, prop, send, Kefir} = require('../test-helpers.coffee')
-
+Combinatorics = require('js-combinatorics');
 
 describe 'delay', ->
 
@@ -30,7 +30,7 @@ describe 'delay', ->
       expect(a.delay(100)).errorsToFlow(a)
 
     it 'works with undependable setTimeout', ->
-      for order in [[false, false], [false, true], [true, false], [true, true]]
+      Combinatorics.baseN([false, true], 2).forEach (order) ->
         a = stream()
         expect(a.delay(0)).toEmitOverShakyTime order, [4, '<end>'], (tick) ->
           send(a, [4])

--- a/test/specs/delay.coffee
+++ b/test/specs/delay.coffee
@@ -1,5 +1,4 @@
-{stream, prop, send, Kefir} = require('../test-helpers.coffee')
-Combinatorics = require('js-combinatorics');
+{stream, prop, send, shakyTimeTest, Kefir} = require('../test-helpers.coffee')
 
 describe 'delay', ->
 
@@ -30,9 +29,9 @@ describe 'delay', ->
       expect(a.delay(100)).errorsToFlow(a)
 
     it 'works with undependable setTimeout', ->
-      Combinatorics.baseN([false, true], 2).forEach (order) ->
+      shakyTimeTest 2, (expectToEmitOverShakyTime) ->
         a = stream()
-        expect(a.delay(0)).toEmitOverShakyTime order, [4, '<end>'], (tick) ->
+        expectToEmitOverShakyTime a.delay(0), [4, '<end>'], (tick) ->
           send(a, [4])
           send(a, ['<end>'])
 

--- a/test/specs/delay.coffee
+++ b/test/specs/delay.coffee
@@ -30,10 +30,10 @@ describe 'delay', ->
       expect(a.delay(100)).errorsToFlow(a)
 
     it 'works with undependable setTimeout', ->
-      for i in [0...10]
+      for order in [[false, false], [false, true], [true, false], [true, true]]
         a = stream()
-        expect(a.delay(0)).toEmitOverShakyTime [i, '<end>'], (tick) ->
-          send(a, [i])
+        expect(a.delay(0)).toEmitOverShakyTime order, [4, '<end>'], (tick) ->
+          send(a, [4])
           send(a, ['<end>'])
 
   describe 'property', ->

--- a/test/specs/delay.coffee
+++ b/test/specs/delay.coffee
@@ -29,6 +29,12 @@ describe 'delay', ->
       a = stream()
       expect(a.delay(100)).errorsToFlow(a)
 
+    it 'works with undependable setTimeout', ->
+      for i in [0...10]
+        a = stream()
+        expect(a.delay(0)).toEmitOverShakyTime [i, '<end>'], (tick) ->
+          send(a, [i])
+          send(a, ['<end>'])
 
   describe 'property', ->
 

--- a/test/test-helpers.coffee
+++ b/test/test-helpers.coffee
@@ -145,18 +145,18 @@ beforeEach ->
 
     # Test with setTimeout not guaranteeing order. See
     # https://github.com/rpominov/kefir/issues/134
-    toEmitOverShakyTime: (expectedLog, cb, timeLimit = 1000) ->
+    toEmitOverShakyTime: (stOrder, expectedLog, cb, timeLimit = 1000) ->
       log = null
       exports.withFakeTime (tick) =>
         originalST = global.setTimeout
         global.setTimeout = ->
-          if Math.random() > 0.5
-            originalST.apply this, arguments
-          else
+          if stOrder.shift()
             _arguments = arguments
             originalST =>
               originalST.apply this, _arguments
             , 0
+          else
+            originalST.apply this, arguments
         log = exports.watchWithTime(@actual)
         cb?(tick)
         tick(timeLimit)

--- a/test/test-helpers.coffee
+++ b/test/test-helpers.coffee
@@ -1,5 +1,6 @@
 Kefir = require("../dist/kefir")
 sinon = require('sinon')
+Combinatorics = require('js-combinatorics')
 
 Kefir.DEPRECATION_WARNINGS = false;
 
@@ -67,6 +68,36 @@ exports.prop = ->
 
 exports.stream = ->
   new Kefir.Stream()
+
+# This will run the callback timeoutCount^timeoutCount times. Each time, the
+# callback will be expected to call setTimeout exactly timeoutCount times. The
+# setTimeout callbacks may be scheduled as normal, or with an up to
+# timeoutCount-1 extra delay added. This will test all combinations. This is to
+# test compatibility with browser bugs that reorder setTimeout callbacks. See
+# https://github.com/rpominov/kefir/issues/134 for more information.
+exports.shakyTimeTest = (timeoutCount, cb) ->
+  delayValues = [0..timeoutCount-1]
+  Combinatorics.baseN(delayValues, timeoutCount).forEach (order) =>
+    expectToEmitOverShakyTime = (stream, expectedLog, cb, timeLimit = 10000) =>
+      log = null
+      exports.withFakeTime (tick) =>
+        originalST = global.setTimeout
+        global.setTimeout = sinon.spy ->
+          delay = order.shift()
+          if delay == 0
+            originalST.apply this, arguments
+          else
+            _arguments = arguments
+            originalST =>
+              originalST.apply this, _arguments
+            , delay
+        log = exports.watchWithTime(stream)
+        cb?(tick)
+        tick(timeLimit)
+        expect(global.setTimeout.callCount).toBe(timeoutCount)
+        global.setTimeout = originalST
+      expect(log.map ([time, value]) -> value).toEqual(expectedLog)
+    cb expectToEmitOverShakyTime
 
 exports.withFakeTime = (cb) ->
   clock = sinon.useFakeTimers(10000)
@@ -142,27 +173,6 @@ beforeEach ->
         tick(timeLimit)
       @message = -> "Expected to emit #{jasmine.pp(expectedLog)}, actually emitted #{jasmine.pp(log)}"
       @env.equals_(expectedLog, log)
-
-    # Test with setTimeout not guaranteeing order. See
-    # https://github.com/rpominov/kefir/issues/134
-    toEmitOverShakyTime: (stOrder, expectedLog, cb, timeLimit = 1000) ->
-      log = null
-      exports.withFakeTime (tick) =>
-        originalST = global.setTimeout
-        global.setTimeout = ->
-          if stOrder.shift()
-            _arguments = arguments
-            originalST =>
-              originalST.apply this, _arguments
-            , 0
-          else
-            originalST.apply this, arguments
-        log = exports.watchWithTime(@actual)
-        cb?(tick)
-        tick(timeLimit)
-        global.setTimeout = originalST
-      @message = -> "Expected to emit #{jasmine.pp(expectedLog)}, actually emitted #{jasmine.pp(log)}"
-      @env.equals_(expectedLog, log.map ([time, value]) -> value)
 
     toActivate: (obss...) ->
 


### PR DESCRIPTION
This fixes #134 and works around browser bugs that cause setTimeout callbacks to not be executed in the correct order.

Currently in `delay`, there is a buffer that holds values to emit. When the source stream emits a value, the value gets put into the buffer, and setTimeout is used to schedule pulling one item out of the buffer. When the source stream ends, setTimeout is used to schedule ending the delayed stream. The issue is that if the browser executes the setTimeout callback for ending the stream before executing the remaining callbacks for flushing the buffer, then the stream ends before the buffer has been cleared, and then an exception is thrown when we try to flush the buffer after the stream has ended.

This change makes it so when the source stream ends, we place a special sentinel value in the buffer, and only end the stream when we flush this value out. Because the end event is now in the value buffer, we don't have to rely on the browser to stop it from being processed out of turn. This unifies the handling of how value and end events are delayed, and happens to work around browser setTimeout bugs.