### PR TITLE
fix(Symbol.observable): Ensure compatability with other polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "transducers-js": "0.4.174",
     "transducers.js": "0.3.2",
     "zen-observable": "0.1.3"
+  },
+  "dependencies": {
+    "symbol-observable": "^0.2.4"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -86,8 +86,8 @@ import fromESObservable from './interop/from-es-observable';
 // (Stream|Property) -> ES7 Observable
 import toESObservable from './interop/to-es-observable';
 Observable.prototype.toESObservable = toESObservable;
-import symbol from './utils/symbol'
-Observable.prototype[symbol('observable')] = toESObservable;
+import $$observable from 'symbol-observable';
+Observable.prototype[$$observable] = toESObservable;
 
 
 

--- a/src/interop/from-es-observable.js
+++ b/src/interop/from-es-observable.js
@@ -1,9 +1,8 @@
 import stream from '../primary/stream';
-import symbol_ from '../utils/symbol';
-const symbol = symbol_('observable');
+import $$observable from 'symbol-observable';
 
 export default function fromESObservable(_observable) {
-  const observable = _observable[symbol] ? _observable[symbol]() : _observable;
+  const observable = _observable[$$observable] ? _observable[$$observable]() : _observable;
   return stream(function(emitter) {
     const unsub = observable.subscribe({
       error(error) {

--- a/src/utils/symbol.js
+++ b/src/utils/symbol.js
@@ -1,9 +1,0 @@
-export default function(key) {
-  if (typeof Symbol !== 'undefined' && Symbol[key]) {
-    return Symbol[key];
-  } else if (typeof Symbol !== 'undefined' && typeof Symbol.for === 'function') {
-    return Symbol.for(key);
-  } else {
-    return '@@' + key;
-  }
-}


### PR DESCRIPTION
`Symbol.observable !== Symbol.for('observable')`

Moves to using [symbol-observable](http://npmjs.org/package/symbol-observable)

Resolves #199 

With 💖 ... the RxJS community. 🍻