### PR TITLE
Add observable symbol to interop prototype

### DIFF
--- a/src/interop/to-es-observable.js
+++ b/src/interop/to-es-observable.js
@@ -1,3 +1,4 @@
+import $$observable from 'symbol-observable';
 import {extend} from '../utils/objects';
 import {VALUE, ERROR, END} from '../constants';
 
@@ -19,6 +20,9 @@ extend(ESObservable.prototype, {
 
     this._observable.onAny(fn);
     return () => this._observable.offAny(fn);
+  },
+  [$$observable]() {
+    return this;
   }
 });
 


### PR DESCRIPTION
The current implementation doesn't include the symbol on the
prototype, meaning it can't be discovered as an observable by
checking `obs[$$observable]`. This rectifies that issue.