### PR TITLE
Assign $$observable to prototype directly

### DIFF
--- a/src/interop/to-es-observable.js
+++ b/src/interop/to-es-observable.js
@@ -20,12 +20,13 @@ extend(ESObservable.prototype, {
 
     this._observable.onAny(fn);
     return () => this._observable.offAny(fn);
-  },
-  [$$observable]() {
-    return this;
   }
 });
 
+// Need to assign directly b/c Symbols aren't enumerable.
+ESObservable.prototype[$$observable] = function() {
+  return this;
+};
 
 export default function toESObservable() {
   return new ESObservable(this);


### PR DESCRIPTION
The previous implementation didn't work because you can't assign
an object's `Symbol`s to another object. Symbol properties
aren't enumerable, so they don't get assigned with `extend`.
It has to be assigned directly to the prototype object.