### PR TITLE
Add observe method to Kefir.Observable

### DIFF
--- a/docs-src/descriptions/main-methods.jade
+++ b/docs-src/descriptions/main-methods.jade
@@ -1,5 +1,57 @@
 h2#main-methods Subscribe / add side effects
 
++descr-method('observe', 'observe', 'obs.observe(Observer|callback)').
+  Subscribes the provided Observer to #[tt obs]. Observer is an object with 3 optional methods:
+
+ul
+  li #[b next] - called on values from the observable
+  li #[b error] - called on errors from the observable
+  li #[b complete] - called on end of the observable
+
+p.
+  Returns a #[tt Subscription] object, which has
+  an #[tt unsubscribe] method and a read-only #[tt closed] property.
+  #[tt closed] indicates whether the #[tt unsubscribe] method has been called
+  and the subscription to the observable has been closed.
+
+pre.javascript(title='example')
+  :escapehtml
+    var stream = Kefir.sequentially(1000, [1, 2]);
+    subscription = stream.observer({
+      next(value) {
+        console.log('value', value)
+      },
+      error(value) {
+        console.log('error', value)
+      },
+      complete(value) {
+        console.log('closed', subscription)
+      },
+    });
+
+pre(title='console output')
+  :escapehtml
+    > value: 1
+    > value: 2
+    > complete: undefined
+
+p.
+  In addition to passing in an Observer, #[tt observe] can takes 1-3 callbacks individually:
+
+pre.javascript(title='example')
+  :escapehtml
+    var stream = Kefir.sequentially(1000, [1, 2]);
+    stream.observer(
+      function onNext(value) {
+        console.log('value', value)
+      },
+      function onError(value) {
+        console.log('error', value)
+      },
+      function onComplete(value) {
+        console.log('closed', subscription)
+      }
+    );
 
 +descr-method('on-value', 'onValue', 'obs.onValue(callback)').
   Subscribes #[b callback] to values on an observable.

--- a/docs-src/descriptions/main-methods.jade
+++ b/docs-src/descriptions/main-methods.jade
@@ -17,7 +17,7 @@ p.
 pre.javascript(title='example')
   :escapehtml
     var stream = Kefir.sequentially(1000, [1, 2]);
-    subscription = stream.observer({
+    var subscription = stream.observer({
       next(value) {
         console.log('value', value)
       },
@@ -28,6 +28,10 @@ pre.javascript(title='example')
         console.log('closed', subscription)
       },
     });
+
+    ...
+    // later
+    subscription.unsubscribe()
 
 pre(title='console output')
   :escapehtml

--- a/docs-src/includes/side-menu.jade
+++ b/docs-src/includes/side-menu.jade
@@ -32,6 +32,7 @@ ul.toc-section
 
 a.toc-title(href='#main-methods') Subscribe / add side effects
 ul.toc-section
+  +method('#observe', 'observe')
   +method('#on-value', 'onValue')
   +method('#off-value', 'offValue')
   +method('#on-error', 'onError')

--- a/src/emitter.js
+++ b/src/emitter.js
@@ -20,5 +20,5 @@ export default function emitter(obs) {
     return obs._active;
   }
 
-  return {value, error, end, event, emit: value, emitEvent: event};
+  return {value, error, end, event, emit: value, emitEvent: event, next: value, complete: end};
 }

--- a/src/observable.js
+++ b/src/observable.js
@@ -126,33 +126,25 @@ extend(Observable.prototype, {
       };
     }
 
-    if (observer.next) {
-      this.onValue(observer.next);
-    }
+    const fn = function(event) {
+      if (event.type === VALUE && observer.next) {
+        observer.next(event.value);
+      } else if (event.type === ERROR && observer.error) {
+        observer.error(event.value);
+      } else if (event.type === END && observer.complete) {
+        observer.complete(event.value);
+      }
+    };
 
-    if (observer.error) {
-      this.onError(observer.error);
-    }
-
-    if (observer.end) {
-      this.onEnd(observer.complete);
-    }
+    this.onAny(fn);
 
     return {
       unsubscribe() {
-        if (observer.next) {
-          _this.offValue(observer.next);
-        }
+        if (!closed) {
+          _this.offAny(fn);
 
-        if (observer.error) {
-          _this.offError(observer.error);
+          closed = true;
         }
-
-        if (observer.end) {
-          _this.offEnd(observer.complete);
-        }
-
-        closed = true;
       },
       closed() {
         return closed;

--- a/src/observable.js
+++ b/src/observable.js
@@ -133,6 +133,7 @@ extend(Observable.prototype, {
         observer.error(event.value);
       } else if (event.type === END && observer.complete) {
         observer.complete(event.value);
+        closed = true;
       }
     };
 

--- a/src/observable.js
+++ b/src/observable.js
@@ -114,15 +114,15 @@ extend(Observable.prototype, {
     return this._off(ANY, fn);
   },
 
-  subscribe(observer) {
+  subscribe(observer, onError, onComplete) {
     const _this = this;
     let closed = false;
 
     if (typeof observer === 'function') {
       observer = {
         next: observer,
-        error: arguments[1],
-        complete: arguments[2]
+        error: onError,
+        complete: onComplete
       };
     }
 

--- a/src/observable.js
+++ b/src/observable.js
@@ -114,6 +114,52 @@ extend(Observable.prototype, {
     return this._off(ANY, fn);
   },
 
+  subscribe(observer) {
+    const _this = this;
+    let closed = false;
+
+    if (typeof observer === 'function') {
+      observer = {
+        next: observer,
+        error: arguments[1],
+        complete: arguments[2]
+      };
+    }
+
+    if (observer.next) {
+      this.onValue(observer.next);
+    }
+
+    if (observer.error) {
+      this.onError(observer.error);
+    }
+
+    if (observer.end) {
+      this.onEnd(observer.complete);
+    }
+
+    return {
+      unsubscribe() {
+        if (observer.next) {
+          _this.offValue(observer.next);
+        }
+
+        if (observer.error) {
+          _this.offError(observer.error);
+        }
+
+        if (observer.end) {
+          _this.offEnd(observer.complete);
+        }
+
+        closed = true;
+      },
+      closed() {
+        return closed;
+      }
+    };
+  },
+
   // A and B must be subclasses of Stream and Property (order doesn't matter)
   _ofSameType(A, B) {
     return A.prototype.getType() === this.getType() ? A : B;

--- a/src/observable.js
+++ b/src/observable.js
@@ -114,7 +114,7 @@ extend(Observable.prototype, {
     return this._off(ANY, fn);
   },
 
-  subscribe(observer, onError, onComplete) {
+  observe(observer, onError, onComplete) {
     const _this = this;
     let closed = false;
 
@@ -146,7 +146,7 @@ extend(Observable.prototype, {
           closed = true;
         }
       },
-      closed() {
+      get closed() {
         return closed;
       }
     };

--- a/test/specs/kefir-observable.js
+++ b/test/specs/kefir-observable.js
@@ -1,0 +1,51 @@
+let {Kefir} = require('../test-helpers.coffee');
+
+describe('Kefir.Observable', function () {
+  describe('observe', function () {
+    let em, count, obs, sub;
+
+    beforeEach(function () {
+      em = null;
+      count = 0;
+      obs = Kefir.stream(_em => {
+        em = _em;
+      });
+      sub = obs.observe({next: () => count++, error: () => count--, complete: () => count = 0});
+    });
+
+    it('should return a Subscription', function () {
+      expect(sub.closed).toBe(false);
+      expect(typeof sub.unsubscribe).toBe('function');
+    });
+
+    it('should call Observer methods', function () {
+      expect(count).toBe(0);
+
+      em.emit(1);
+      expect(count).toBe(1);
+
+      em.emit(1);
+      expect(count).toBe(2);
+
+      em.error(1);
+      expect(count).toBe(1);
+
+      em.end();
+      expect(count).toBe(0);
+      expect(sub.closed).toBe(true);
+    });
+
+    it('should unsubcribe early', function () {
+      expect(count).toBe(0);
+
+      em.emit(1);
+      expect(count).toBe(1);
+
+      sub.unsubscribe();
+
+      em.emit(1);
+      expect(count).toBe(1);
+      expect(sub.closed).toBe(true);
+    });
+  });
+});

--- a/test/specs/kefir-observable.js
+++ b/test/specs/kefir-observable.js
@@ -1,10 +1,10 @@
 let {Kefir} = require('../test-helpers.coffee');
 
-describe('Kefir.Observable', function () {
-  describe('observe', function () {
+describe('Kefir.Observable', () => {
+  describe('observe', () => {
     let em, count, obs, sub;
 
-    beforeEach(function () {
+    beforeEach(() => {
       em = null;
       count = 0;
       obs = Kefir.stream(_em => {
@@ -13,12 +13,12 @@ describe('Kefir.Observable', function () {
       sub = obs.observe({next: () => count++, error: () => count--, complete: () => count = 0});
     });
 
-    it('should return a Subscription', function () {
+    it('should return a Subscription', () => {
       expect(sub.closed).toBe(false);
       expect(typeof sub.unsubscribe).toBe('function');
     });
 
-    it('should call Observer methods', function () {
+    it('should call Observer methods', () => {
       expect(count).toBe(0);
 
       em.emit(1);
@@ -35,7 +35,7 @@ describe('Kefir.Observable', function () {
       expect(sub.closed).toBe(true);
     });
 
-    it('should unsubcribe early', function () {
+    it('should unsubcribe early', () => {
       expect(count).toBe(0);
 
       em.emit(1);


### PR DESCRIPTION
I'm going to lead off by saying I know this doesn't match the [comment](https://github.com/rpominov/kefir/issues/103#issuecomment-100713065) you made. I don't have strong feelings about the difference between `observe` / `subscribe` and the subscription token vs unsub function. However, I do think if we're going to add a method that does something similar to `subscribe`, we should adhere to standards for better interoperability. That's what this matches up with.

I'm happy to change around the layout if you'd really prefer the alternate you laid out above, or even include them both, but I'd like to make the case that adhering to the es-observable standard is the way to go here.

I'm still getting a feel for the codebase, so if there's a better way to implement this, definitely interested in feedback as well.

Fixes #151.