### PR TITLE
Add 'chain' synonym for flatMap.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -332,6 +332,7 @@ import FlatMap from './many-sources/flat-map';
 Observable.prototype.flatMap = function(fn) {
   return new FlatMap(this, fn).setName(this, 'flatMap');
 };
+Observable.prototype.chain = Observable.prototype.flatMap;
 Observable.prototype.flatMapLatest = function(fn) {
   return new FlatMap(this, fn, {concurLim: 1, drop: 'old'}).setName(this, 'flatMapLatest');
 };


### PR DESCRIPTION
This makes operation with fantasyland-compatible libraries (e.g. Ramda) a bit smoother.

I didn't realize you had #160 open before posting this PR. I hope you can consider it anyway. Thanks.