### PR TITLE
flow: .filter() and .filter(Boolean) removes falsey values from stream

### DIFF
--- a/kefir.js.flow
+++ b/kefir.js.flow
@@ -47,7 +47,8 @@ declare class Observable<+V,+E=*> {
   toPromise(PromiseConstructor?: Function): Promise<V>;
 
   map<V2>(cb: (v: V) => V2): Observable<V2,E>;
-  filter(cb?: (v: V) => any): Observable<V,E>;
+  filter(cb?: typeof Boolean): Observable<$NonMaybeType<V>,E>;
+  filter(cb: (v: V) => any): Observable<V,E>;
   take(n: number): Observable<V,E>;
   takeWhile(cb?: (v: V) => boolean): Observable<V,E>;
   last(): Observable<V,E>;
@@ -64,6 +65,7 @@ declare class Observable<+V,+E=*> {
   throttle(n: number, options?: {leading?: boolean, trailing?: boolean}): Observable<V,E>;
   debounce(n: number, options?: {immediate?: boolean}): Observable<V,E>;
   mapErrors<E2>(fn: (error: E) => E2): Observable<V,E2>;
+  filterErrors(fn?: typeof Boolean): Observable<V,$NonMaybeType<E>>;
   filterErrors(fn: (error: E) => any): Observable<V,E>;
   takeErrors(n: number): Observable<V,E>;
   ignoreValues(): Observable<*,E>;

--- a/test/flow/filter.js
+++ b/test/flow/filter.js
@@ -1,0 +1,48 @@
+/* @flow */
+
+import Kefir from '../../kefir';
+
+Kefir.sequentially(10, [5, null])
+  .onValue(x => {
+    const good: ?number = x;
+    // $ExpectError
+    const bad1: number = x;
+    // $ExpectError
+    const bad2: null = x;
+  })
+  .filter()
+  .onValue(x => {
+    const good: number = x;
+    // $ExpectError
+    const bad: null = x;
+  });
+
+Kefir.sequentially(10, [5, null])
+  .onValue(x => {
+    const good: ?number = x;
+    // $ExpectError
+    const bad1: number = x;
+    // $ExpectError
+    const bad2: null = x;
+  })
+  .filter(Boolean)
+  .onValue(x => {
+    const good: number = x;
+    // $ExpectError
+    const bad: null = x;
+  });
+
+Kefir.sequentially(10, [5, null])
+  .onValue(x => {
+    const good: ?number = x;
+    // $ExpectError
+    const bad1: number = x;
+    // $ExpectError
+    const bad2: null = x;
+  })
+  .filter(x => true)
+  .onValue(x => {
+    const good: ?number = x;
+    // $ExpectError
+    const bad: number = x;
+  });


### PR DESCRIPTION
This makes it so Flow knows that calling `.filter()` or `.filter(Boolean)` on a stream returns a new one with the falsey values removed.

It's based on Flow's similar recent support for `.filter(Boolean)` on arrays. I originally wanted to get this in with my last pull request, but I was just testing with an old version of Flow and thought it wasn't going to work.