### PR TITLE
Flow definition fix and updates

### DIFF
--- a/kefir.js.flow
+++ b/kefir.js.flow
@@ -136,7 +136,7 @@ declare var Kefir: {
   interval<V>(interval: number, value: V): Observable<V,*>;
   sequentially<V>(interval: number, values: V[]): Observable<V,*>;
   fromPoll<V>(interval: number, f: () => V): Observable<V,*>;
-  withInterval<V>(interval: number, f: (emitter: Emitter<V>) => void): Observable<V,*>;
+  withInterval<V,E>(interval: number, f: (emitter: Emitter<V,E>) => void): Observable<V,E>;
   fromCallback<V>(f: (cb: (value: V) => void) => void): Observable<V,*>;
   fromNodeCallback<V,E>(f: (cb: (err: E, value: ?V) => void) => void): Observable<V,E>;
   fromEvents(target: Object, eventName: string, transformer?: (event: any) => any): Observable<any,*>;

--- a/kefir.js.flow
+++ b/kefir.js.flow
@@ -22,9 +22,9 @@ export type Subscription = {
 };
 
 export type Observer<V,E> = {
-  value?: (value: V) => void;
-  error?: (err: E) => void;
-  end?: () => void;
+  +value?: (value: V) => void;
+  +error?: (err: E) => void;
+  +end?: () => void;
 };
 
 declare class Observable<+V,+E=*> {
@@ -32,7 +32,7 @@ declare class Observable<+V,+E=*> {
   toProperty<V2>(getCurrent: () => V2): Property<V|V2,E>;
   changes(): Observable<V,E>;
 
-  observe(obs: Observer<V,E>): Subscription;
+  observe(obs: Observer<V,E>, ...none: empty[]): Subscription;
   observe(onValue: ?(v: V) => void, onError: ?(err: E) => void, onEnd: ?() => void): Subscription;
   onValue(cb: (v: V) => void): this;
   offValue(cb: (v: V) => void): this;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "coffee-script": "1.10.0",
     "coffeeify": "1.1.0",
     "eslint": "2.2.0",
-    "flow-bin": "^0.31.1",
+    "flow-bin": "^0.36.0",
     "grunt": "0.4.5",
     "grunt-bower-task": "0.4.0",
     "grunt-browserify": "4.0.1",

--- a/test/flow/explicitType.js
+++ b/test/flow/explicitType.js
@@ -9,7 +9,7 @@ const p1c: Observable<{a:number}> = p1;
 // $ExpectError
 const f1c: Observable<number> = p1;
 
-p1.observe(v => {
+p1.onValue(v => {
   const good: {a:number, b:string} = v;
   // $ExpectError
   const bad: number = v;
@@ -20,7 +20,7 @@ const p2: Kefir.Observable<{a:number, b:string}> = Kefir.constant({a:2, b:'b'});
 // $ExpectError
 const f2c: Observable<number> = p1;
 
-p2.observe(v => {
+p2.onValue(v => {
   const good: {a:number, b:string} = v;
   // $ExpectError
   const bad: number = v;

--- a/test/flow/observe.js
+++ b/test/flow/observe.js
@@ -1,0 +1,29 @@
+/* @flow */
+
+import Kefir from '../../kefir';
+
+const s1: Kefir.Observable<number> = Kefir.constant(1);
+
+s1.observe({
+  value(x) {
+    const good: number = x;
+    // $ExpectError
+    const bad: string = x;
+  },
+  error: (e) => {
+
+  }
+});
+
+class MyObserver {
+  value(x) {
+    const good: number = x;
+    // $ExpectError
+    const bad: string = x;
+  }
+  error(e) {
+
+  }
+}
+
+s1.observe(new MyObserver());


### PR DESCRIPTION
* The definition of the `withInterval` method was broken. ([Flow seems to only report the error if you use the method, or as of the v0.36, pass a reference to the Kefir object](https://github.com/facebook/flow/issues/2913).)
* Updates to keep compatibility with the latest version of Flow. I figure it's intended that the `observe` method can be passed an instance of a class with value/error/end methods, but instances of classes now have their methods typed as covariant, so the Observer type needed to have its properties marked as covariant (`+` prefix does that now).
* The new version of Flow now often picks the wrong overload of `observe`, because it believes a function could be an Observer object (that just happens to be callable and has none of the value/error/end properties). [There isn't currently a way to specify that the Observer type shouldn't be callable](https://github.com/facebook/flow/issues/2914), so I made it so Flow knows that the Observer object overload can only take one parameter (Flow allows functions to be passed too many arguments by default; I disallow that here by annotating all arguments after the first as needing to be the impossible `empty` type). There's some definition checks added for observe for this.