### PR TITLE
A few improvements for Flow type definitions

### DIFF
--- a/kefir.js.flow
+++ b/kefir.js.flow
@@ -44,12 +44,12 @@ type ESObservable<+V,+E=*> = {
 };
 
 declare class Observable<+V,+E=*> {
-  toProperty(): Property<V,E>;
+  toProperty($?: empty): Property<V,E>;
   toProperty<V2>(getCurrent: () => V2): Property<V|V2,E>;
   changes(): Observable<V,E>;
 
-  observe(obs: Observer<V,E>, ...none: empty[]): Subscription;
-  observe(onValue: ?(v: V) => void, onError: ?(err: E) => void, onEnd: ?() => void): Subscription;
+  observe(obs: Observer<V,E>, $?: empty): Subscription;
+  observe(onValue?: (v: V) => void, onError?: (err: E) => void, onEnd?: () => void): Subscription;
   onValue(cb: (v: V) => void): this;
   offValue(cb: (v: V) => void): this;
   onError(cb: (err: E) => void): this;
@@ -76,12 +76,18 @@ declare class Observable<+V,+E=*> {
   skip(n: number): Observable<V,E>;
   skipWhile(cb?: (v: V) => boolean): Observable<V,E>;
   skipDuplicates(comparator?: (a: V, b: V) => boolean): Observable<V,E>;
-  diff(fn?: (prev: V, next: V) => V): Observable<V,E>;
-  diff<V2>(fn: (prev: V2, next: V) => V, seed: V2): Observable<V2,E>;
-  scan(cb: (prev: V, next: V) => V): Observable<V,E>;
+
+  diff($?: empty): Observable<[V, V],E>;
+  diff<V2>(fn: (prev: V, next: V) => V2, $?: empty): Observable<V2,E>;
+  diff<V2,V3>(fn: (prev: V | V3, next: V) => V2, seed: V3): Observable<V2,E>;
+  diff<V3>(fn: null | void, seed: V3): Observable<[V | V3, V],E>;
+
+  scan(cb: (prev: V, next: V) => V, $?: empty): Observable<V,E>;
   scan<V2>(cb: (prev: V2, next: V) => V2, seed: V2): Observable<V2,E>;
-  flatten(): Observable<any,E>;
+
+  flatten($?: empty): Observable<any,E>;
   flatten<V2>(transformer: (value: V) => V2[]): Observable<V2,E>;
+
   delay(n: number): Observable<V,E>;
   throttle(n: number, options?: {leading?: boolean, trailing?: boolean}): Observable<V,E>;
   debounce(n: number, options?: {immediate?: boolean}): Observable<V,E>;
@@ -98,10 +104,22 @@ declare class Observable<+V,+E=*> {
   transduce(transducer: any): Observable<any,E>;
   withHandler<V2,E2>(handler: (emitter: Emitter<V2,E2>, event: Event<V,E>) => void): Observable<V2,E2>;
 
-  combine<V2,E2>(otherObs: Observable<V2,E2>): Observable<[V,V2],E|E2>;
+  combine<V2,E2>(otherObs: Observable<V2,E2>, $?: empty): Observable<[V,V2],E|E2>;
   combine<V2,V3,E2>(otherObs: Observable<V2,E2>, combinator: (v: V, v2: V2) => V3): Observable<V3,E|E2>;
-  zip<V2,E2>(otherObs: Observable<V2,E2>): Observable<[V,V2],E|E2>;
+  combine<V2,V3,E2,E3>(
+    otherObs: Observable<V2,E2>,
+    passiveObss: Observable<V3,E3>[],
+    $?: empty
+  ): Observable<Array<V|V2|V3>,E|E2|E3>;
+  combine<V2,V3,V4,E2,E3>(
+    otherObs: Observable<V2,E2>,
+    passiveObss: Observable<V3,E3>[],
+    combinator: (v: V, v2: V2, ...v3: V3[]) => V4
+  ): Observable<V4,E|E2|E3>;
+
+  zip<V2,E2>(otherObs: Observable<V2,E2>, $?: empty): Observable<[V,V2],E|E2>;
   zip<V2,V3,E2>(otherObs: Observable<V2,E2>, combinator: (v: V, v2: V2) => V3): Observable<V3,E|E2>;
+
   merge<V2,E2>(otherObs: Observable<V2,E2>): Observable<V|V2,E|E2>;
   concat<V2,E2>(otherObs: Observable<V2,E2>): Observable<V|V2,E|E2>;
 
@@ -117,8 +135,10 @@ declare class Observable<+V,+E=*> {
   takeUntilBy(otherObs: Observable<any,any>): Observable<V,E>;
   bufferBy(otherObs: Observable<any,any>, options?: {flushOnEnd?: boolean}): Observable<V[],E>;
   bufferWhileBy(otherObs: Observable<any,any>, options?: {flushOnEnd?: boolean, flushOnChange?: boolean}): Observable<V[],E>;
-  sampledBy(otherObs: Observable<any,any>): Observable<V,E>;
+
+  sampledBy(otherObs: Observable<any,any>, $?: empty): Observable<V,E>;
   sampledBy<V2,V3>(otherObs: Observable<V2,any>, combinator: (obsValue: V, otherObsValue: V2) => V3): Observable<V3,E>;
+
   bufferWithTimeOrCount(time: number, count: number, options?: {flushOnEnd: boolean}): Observable<V,E>;
 }
 
@@ -171,13 +191,51 @@ declare var Kefir: {
   fromPromise<V,E>(promise: Promise<V>): Property<V,E>;
   fromESObservable<V,E>(observable: ESObservable<V,E>): Observable<V,E>;
 
-  combine<E>(obss: Observable<any,E>[], combinator?: Function): Observable<any,E>;
-  combine<E>(obss: Observable<any,E>[], passiveObss?: Observable<any,E>[], combinator?: Function): Observable<any,E>;
-  combine<E>(obss: {[key:string]:Observable<any,E>}, combinator?: Function): Observable<any,E>;
-  combine<E>(obss: {[key:string]:Observable<any,E>}, passiveObss?: {[key:string]:Observable<any,E>}, combinator?: Function): Observable<any,E>;
+  combine:
+    // array of observables
+    & (<V,E>(obss: Observable<V,E>[], $?: empty) => Observable<V[],E>)
 
-  zip<V,E>(obss: Observable<V,E>[]): Observable<Array<V>,E>;
-  zip<E>(obss: Observable<any,E>[], combinator: Function): Observable<any,E>;
+    // array of observables, combinator
+    & (<V,E>(obss: Observable<any,E>[], combinator: (...args: any[]) => V) => Observable<V,E>)
+
+    // array of observables, array of passive observables
+    & (<V,V2,E,E2>(obss: Observable<V,E>[], passiveObss: Observable<V2,E2>[], $?: empty) => Observable<(V|V2)[],E|E2>)
+
+    // array of observables, array of passive observables, combinator
+    & (<V,E,E2>(obss: Observable<any,E>[], passiveObss: Observable<any,E2>[], combinator: (...args: any[]) => V) => Observable<V,E|E2>)
+
+    // object of observables
+    & (<E, Obss: { [key: string]: Observable<any, E> }>(
+      obss: Obss,
+      $?: empty
+    ) => Observable<$ObjMap<Obss, <V,E2>(_: Observable<V,E2>) => V>,E>)
+
+    // object of observables, combinator
+    & (<V, E, Obss: { [key: string]: Observable<any,E> }>(
+      obss: Obss,
+      combinator: (vs: $ObjMap<Obss, <V2,E2>(_: Observable<V2,E2>) => V2>) => V
+    ) => Observable<V,E>)
+
+    // object of observables, object of passive observables
+    & (<E, E2, Obss: { [key: string]: Observable<any,E> }, PassiveObss: { [key: string]: Observable<any,E2> }>(
+      obss: Obss,
+      passiveObss: PassiveObss,
+      $?: empty
+    ) => Observable<
+      $ObjMap<Obss, <V,E3>(_: Observable<V,E3>) => V>
+      & $ObjMap<PassiveObss, <V,E3>(_: Observable<V,E3>) => V>,
+      E|E2>)
+
+    // object of observables, object of passive observables, combinator
+    & (<V, E, E2, Obss: { [key: string]: Observable<any,E> }, PassiveObss: { [key: string]: Observable<any,E2> }>(
+      obss: Obss,
+      passiveObss: PassiveObss,
+      combinator: (vs: $ObjMap<Obss, <V3,E3>(_: Observable<V3,E3>) => V3> & $ObjMap<PassiveObss, <V3,E3>(_: Observable<V3,E3>) => V3>) => V,
+    ) => Observable<V, E|E2>);
+
+  zip: (<V,E>(obss: Observable<V,E>[], $?: empty) => Observable<V[],E>)
+    & (<V,V2,E>(obss: Observable<any,E>[], combinator: (...args: any[]) => V2) => Observable<V2,E>);
+
   merge<V,E>(obss: Observable<V,E>[]): Observable<V,E>;
   concat<V,E>(obss: Observable<V,E>[]): Observable<V,E>;
 

--- a/kefir.js.flow
+++ b/kefir.js.flow
@@ -1,5 +1,7 @@
 /* @flow */
 
+import type EventEmitter from "events";
+
 export type Event<V,E> =
   {type: 'value', value: V} |
   {type: 'error', value: E} |
@@ -27,6 +29,20 @@ export type Observer<V,E> = {
   +end?: () => void;
 };
 
+/*
+ * This is the interface described by https://github.com/tc39/proposal-observable
+ * It provides interoperability between stream implementations, including Kefir,
+ * RxJS, and zen-observable.
+ */
+type ESObservable<+V,+E=*> = {
+  subscribe(callbacks: {
+    start?: Function,
+    next?: (value: V) => any,
+    error?: (error: E) => any,
+    complete?: () => any,
+  }): { unsubscribe: () => void };
+};
+
 declare class Observable<+V,+E=*> {
   toProperty(): Property<V,E>;
   toProperty<V2>(getCurrent: () => V2): Property<V|V2,E>;
@@ -49,6 +65,7 @@ declare class Observable<+V,+E=*> {
   setName(name: string): this;
   setName(Observable<any, any>, name: string): this;
   toPromise(PromiseConstructor?: Function): Promise<V>;
+  toESObservable(): ESObservable<V,E>;
 
   map<V2>(cb: (v: V) => V2): Observable<V2,E>;
   filter(cb?: typeof Boolean): Observable<$NonMaybeType<V>,E>;
@@ -72,8 +89,8 @@ declare class Observable<+V,+E=*> {
   filterErrors(fn?: typeof Boolean): Observable<V,$NonMaybeType<E>>;
   filterErrors(fn: (error: E) => any): Observable<V,E>;
   takeErrors(n: number): Observable<V,E>;
-  ignoreValues(): Observable<*,E>;
-  ignoreErrors(): Observable<V,*>;
+  ignoreValues(): Observable<empty,E>;
+  ignoreErrors(): Observable<V,empty>;
   ignoreEnd(): Observable<V,E>;
   beforeEnd<V2>(fn: () => V2): Observable<V|V2,E>;
   slidingWindow(max: number, min?: number): Observable<V[],E>;
@@ -133,23 +150,26 @@ declare var Kefir: {
     };
   };
 
-  never(): Observable<*>;
-  later<V>(delay: number, value: V): Observable<V,*>;
-  interval<V>(interval: number, value: V): Observable<V,*>;
-  sequentially<V>(interval: number, values: V[]): Observable<V,*>;
-  fromPoll<V>(interval: number, f: () => V): Observable<V,*>;
+  never(): Observable<empty,empty>;
+  later<V>(delay: number, value: V): Observable<V,empty>;
+  interval<V>(interval: number, value: V): Observable<V,empty>;
+  sequentially<V>(interval: number, values: V[]): Observable<V,empty>;
+  fromPoll<V>(interval: number, f: () => V): Observable<V,empty>;
   withInterval<V,E>(interval: number, f: (emitter: Emitter<V,E>) => void): Observable<V,E>;
-  fromCallback<V>(f: (cb: (value: V) => void) => void): Observable<V,*>;
+  fromCallback<V>(f: (cb: (value: V) => void) => void): Observable<V,empty>;
   fromNodeCallback<V,E>(f: (cb: (err: E, value: ?V) => void) => void): Observable<V,E>;
-  fromEvents(target: Object, eventName: string, transformer?: (event: any) => any): Observable<any,*>;
+  fromEvents<V,E>(
+    target: EventTarget | EventEmitter, // `EventTarget` comes from Flow's built-in dom types
+    eventName: string,
+    transformer?: (...args: any[]) => V
+  ): Observable<V,E>;
   stream<V,E>(subscribe: (emitter: Emitter<V,E>) => ?() => void): Observable<V,E>;
 
-  constant<V>(value: V): Property<V,*>;
-  constantError<E>(err: E): Property<*,E>;
-  fromPromise<V>(promise: Promise<V>): Property<V,any>;
+  constant<V>(value: V): Property<V,empty>;
+  constantError<E>(err: E): Property<empty,E>;
 
-  fromESObservable(observable: Object): Observable<any,*>;
-  toESObservable(): Object;
+  fromPromise<V,E>(promise: Promise<V>): Property<V,E>;
+  fromESObservable<V,E>(observable: ESObservable<V,E>): Observable<V,E>;
 
   combine<E>(obss: Observable<any,E>[], combinator?: Function): Observable<any,E>;
   combine<E>(obss: Observable<any,E>[], passiveObss?: Observable<any,E>[], combinator?: Function): Observable<any,E>;

--- a/kefir.js.flow
+++ b/kefir.js.flow
@@ -152,6 +152,19 @@ declare class Stream<+V,+E=*> extends Observable<V,E> {
 declare class Property<+V,+E=*> extends Observable<V,E> {
 }
 
+// `$observedValuesTuple` is a helper type that describes a type for a tuple or
+// array of values in relation to a tuple or array of observables. This mapping
+// states that the type of each position in the new tuple type matches the type
+// of the value type parameter of the observable in the same position in the
+// input tuple.
+type $observedValuesTuple<Obss> = $TupleMap<Obss, <V,E>(obs: Observable<V,E>) => V>
+
+// `$observedValuesObject` is similar to `$observedValuesTuple` - except that
+// `$observedValuesObject` describes an object type where the type of each
+// property in the new object matches the value type parameter of the observable
+// type under the same key in the input object.
+type $observedValuesObject<Obss> = $ObjMap<Obss, <V,E>(obs: Observable<V,E>) => V>
+
 declare var Kefir: {
   Observable: typeof Observable;
   Pool: typeof Pool;
@@ -193,7 +206,10 @@ declare var Kefir: {
 
   combine:
     // array of observables
-    & (<V,E>(obss: Observable<V,E>[], $?: empty) => Observable<V[],E>)
+    & (<E, Obss: Observable<any,E>[]>(
+      obss: Obss,
+      $?: empty
+    ) => Observable<$observedValuesTuple<Obss>, E>)
 
     // array of observables, combinator
     & (<V,E>(obss: Observable<any,E>[], combinator: (...args: any[]) => V) => Observable<V,E>)
@@ -208,12 +224,12 @@ declare var Kefir: {
     & (<E, Obss: { [key: string]: Observable<any, E> }>(
       obss: Obss,
       $?: empty
-    ) => Observable<$ObjMap<Obss, <V,E2>(_: Observable<V,E2>) => V>,E>)
+    ) => Observable<$observedValuesObject<Obss>, E>)
 
     // object of observables, combinator
     & (<V, E, Obss: { [key: string]: Observable<any,E> }>(
       obss: Obss,
-      combinator: (vs: $ObjMap<Obss, <V2,E2>(_: Observable<V2,E2>) => V2>) => V
+      combinator: (vs: $observedValuesObject<Obss>) => V
     ) => Observable<V,E>)
 
     // object of observables, object of passive observables
@@ -222,18 +238,21 @@ declare var Kefir: {
       passiveObss: PassiveObss,
       $?: empty
     ) => Observable<
-      $ObjMap<Obss, <V,E3>(_: Observable<V,E3>) => V>
-      & $ObjMap<PassiveObss, <V,E3>(_: Observable<V,E3>) => V>,
+      $observedValuesObject<Obss> & $observedValuesObject<PassiveObss>,
       E|E2>)
 
     // object of observables, object of passive observables, combinator
     & (<V, E, E2, Obss: { [key: string]: Observable<any,E> }, PassiveObss: { [key: string]: Observable<any,E2> }>(
       obss: Obss,
       passiveObss: PassiveObss,
-      combinator: (vs: $ObjMap<Obss, <V3,E3>(_: Observable<V3,E3>) => V3> & $ObjMap<PassiveObss, <V3,E3>(_: Observable<V3,E3>) => V3>) => V,
+      combinator: (vs: $observedValuesObject<Obss> & $observedValuesObject<PassiveObss>) => V,
     ) => Observable<V, E|E2>);
 
-  zip: (<V,E>(obss: Observable<V,E>[], $?: empty) => Observable<V[],E>)
+  zip:
+    & (<E, Obss: Observable<any,E>[]>(
+      obss: Obss,
+      $?: empty
+    ) => Observable<$observedValuesTuple<Obss>, E>)
     & (<V,V2,E>(obss: Observable<any,E>[], combinator: (...args: any[]) => V2) => Observable<V2,E>);
 
   merge<V,E>(obss: Observable<V,E>[]): Observable<V,E>;

--- a/kefir.js.flow
+++ b/kefir.js.flow
@@ -49,7 +49,7 @@ declare class Observable<+V,+E=*> {
   changes(): Observable<V,E>;
 
   observe(obs: Observer<V,E>, $?: empty): Subscription;
-  observe(onValue?: (v: V) => void, onError?: (err: E) => void, onEnd?: () => void): Subscription;
+  observe(onValue?: ?(v: V) => void, onError?: ?(err: E) => void, onEnd?: ?() => void): Subscription;
   onValue(cb: (v: V) => void): this;
   offValue(cb: (v: V) => void): this;
   onError(cb: (err: E) => void): this;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@reactivex/rxjs": "5.3.0",
     "babel-preset-es2015-loose-rollup": "7.0.0",
     "coffee-script": "1.12.5",
-    "flow-bin": "0.44.0",
+    "flow-bin": "0.46.0",
     "inquirer": "0.10.1",
     "jasmine-node": "1.14.5",
     "prettier": "1.0.2",

--- a/test/flow/combine.js
+++ b/test/flow/combine.js
@@ -1,0 +1,154 @@
+/* @flow */
+
+import Kefir from '../../kefir'
+
+const numbers = Kefir.sequentially(0, [1, 2, 3, 4])
+const strings = Kefir.sequentially(0, ['foo', 'bar', 'baz'])
+const functions = Kefir.sequentially(0, [(n: number) => 'foobar'])
+
+function test_combine_method() {
+  const xs = numbers.combine(strings)
+
+  xs.onValue((x: [number, string]) => {})
+
+  // $ExpectError
+  xs.onValue((x: number | string) => {})
+}
+
+function test_combine_method_withCombinator() {
+  const xs = numbers.combine(strings, (n, s) => `${n}: ${s}`)
+
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: [number, string]) => {})
+
+  // $ExpectError
+  xs.onValue((x: number) => {})
+}
+
+function test_combine_method_withCombinatorAndPassive() {
+  const xs = numbers.combine(strings, [functions], (n, s, f) => f(n) + s)
+
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: [number, string]) => {})
+
+  // $ExpectError
+  xs.onValue((x: number) => {})
+}
+
+function test_combine_method_withPassive() {
+  const xs = numbers.combine(strings, [functions])
+
+  xs.onValue((x: (number | string | Function)[]) => {})
+
+  // $ExpectError
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: number | string | Function) => {})
+}
+
+function test_combine() {
+  const xs = Kefir.combine([numbers, strings])
+
+  xs.onValue((x: (number | string)[]) => {})
+
+  // $ExpectError
+  xs.onValue((x: number | string) => {})
+}
+
+function test_combine_withCombinator() {
+  const xs = Kefir.combine([numbers, strings], (n, s) => `${n}: ${s}`)
+
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: [number, string]) => {})
+
+  // $ExpectError
+  xs.onValue((x: number) => {})
+}
+
+function test_combine_withCombinatorAndPassive() {
+  const xs = Kefir.combine([numbers, strings], [functions], (n, s, f) => 'foo')
+
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: [number, string]) => {})
+
+  // $ExpectError
+  xs.onValue((x: number) => {})
+}
+
+function test_combine_withPassive() {
+  const xs = Kefir.combine([numbers, strings], [functions])
+
+  xs.onValue((x: (number | string | Function)[]) => {})
+
+  // $ExpectError
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: number | string | Function) => {})
+}
+
+function test_combine_object() {
+  const xs = Kefir.combine({numbers, strings})
+
+  xs.onValue((x: {numbers: number, strings: string}) => {})
+
+  // $ExpectError
+  xs.onValue((x: {numbers: string, strings: string}) => {})
+
+  // $ExpectError
+  xs.onValue((x: [number, string]) => {})
+}
+
+function test_combine_object_withCombinator() {
+  const xs = Kefir.combine(
+    {numbers, strings},
+    (args: {numbers: number, strings: string}) => `${args.numbers}: ${args.strings}`
+  )
+
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: {numbers: number, strings: string}) => {})
+
+  // $ExpectError
+  xs.onValue((x: [number, string]) => {})
+}
+
+function test_combine_object_withCombinatorAndPassive() {
+  const xs = Kefir.combine({numbers, strings}, {functions}, (args: {
+    numbers: number,
+    strings: string,
+    functions: (n: number) => string,
+  }) => {
+    return args.functions(args.numbers) + args.strings
+  })
+
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: {numbers: number, strings: string}) => {})
+
+  // $ExpectError
+  xs.onValue((x: [number, string]) => {})
+}
+
+function test_combine_object_withPassive() {
+  const xs = Kefir.combine({numbers, strings}, {functions})
+
+  xs.onValue((x: {numbers: number, strings: string, functions: (n: number) => string}) => {})
+
+  // $ExpectError
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: [number, string]) => {})
+}

--- a/test/flow/diff.js
+++ b/test/flow/diff.js
@@ -1,0 +1,47 @@
+/* @flow */
+
+import Kefir from '../../kefir'
+
+const source = Kefir.sequentially(10, [1, 2, 3, 4])
+
+function test_diff_noArgs() {
+  const xs = source.diff()
+
+  xs.onValue((x: [number, number]) => {})
+
+  // $ExpectError
+  xs.onValue((x: number) => {})
+}
+
+function test_diff_fn() {
+  const xs = source.diff((x, y) => x - y)
+
+  xs.onValue((x: number) => {})
+
+  // $ExpectError
+  xs.onValue((x: [number, number]) => {})
+}
+
+function test_diff_fnAndSeed() {
+  const xs = source.diff((x, y) => x - y, 0)
+
+  // $ExpectError
+  source.diff((x, y) => x - y, 'zero')
+
+  xs.onValue((x: number) => {})
+
+  // $ExpectError
+  xs.onValue((x: [number, number]) => {})
+}
+
+function test_diff_seed() {
+  const xs = source.diff(null, 'zero')
+
+  xs.onValue((x: [number | string, number]) => {})
+
+  // $ExpectError
+  xs.onValue((x: [number, number]) => {})
+
+  // $ExpectError
+  xs.onValue((x: number) => {})
+}

--- a/test/flow/flatten.js
+++ b/test/flow/flatten.js
@@ -1,0 +1,20 @@
+/* @flow */
+
+import Kefir from '../../kefir'
+
+function test_flatten() {
+  const source = Kefir.sequentially(0, [[1], [2, 2], [3, 3, 3]])
+  const xs = source.flatten()
+
+  xs.onValue((x: number) => {})
+}
+
+function test_flatten_withTransformer() {
+  const source = Kefir.sequentially(0, [1, 2, 3, 4])
+  const xs = source.flatten(x => ['foo', 'bar'])
+
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: number) => {})
+}

--- a/test/flow/interop.js
+++ b/test/flow/interop.js
@@ -1,0 +1,81 @@
+/* @flow */
+
+import Kefir from '../../kefir'
+
+import EventEmitter from 'events'
+
+class MyEmitter extends EventEmitter {}
+
+function test_fromEvents() {
+  const ee = new MyEmitter()
+  const xs = Kefir.fromEvents(ee, 'somethingHappened', (x: string, y: number) => 'foo')
+
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: number) => {})
+}
+
+function test_toPromise() {
+  const xs = Kefir.constant('foo')
+  const p = xs.toPromise()
+
+  p.then((x: string) => {})
+
+  // $ExpectError
+  p.then((x: number) => {})
+}
+
+function test_fromPromise() {
+  const p = Promise.resolve('foo')
+  const xs = Kefir.fromPromise(p)
+
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: number) => {})
+}
+
+function test_fromESObservable() {
+  const myObservable = {
+    subscribe({next, error, complete}) {
+      next && next('foo')
+      error && error(new Error())
+      complete && complete()
+      return {
+        unsubscribe() {},
+      }
+    },
+  }
+
+  const xs = Kefir.fromESObservable(myObservable)
+
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: number) => {})
+
+  xs.onError((e: Error) => {})
+
+  // $ExpectError
+  xs.onError((e: number) => {})
+}
+
+function test_toESObservable() {
+  const xs: Kefir.Observable<string, Error> = Kefir.constant('foo')
+  const obs = xs.toESObservable()
+
+  obs.subscribe({
+    next: (x: string) => {},
+    error: (e: Error) => {},
+    complete: () => {},
+  })
+
+  obs.subscribe({
+    // $ExpectError
+    next: (x: number) => {},
+    // $ExpectError
+    error: (e: number) => {},
+    complete: () => {},
+  })
+}

--- a/test/flow/observe.js
+++ b/test/flow/observe.js
@@ -23,3 +23,5 @@ class MyObserver {
 }
 
 s1.observe(new MyObserver())
+
+s1.observe(value => {}, error => {}, () => {})

--- a/test/flow/observe.js
+++ b/test/flow/observe.js
@@ -25,3 +25,6 @@ class MyObserver {
 s1.observe(new MyObserver())
 
 s1.observe(value => {}, error => {}, () => {})
+
+s1.observe(value => {})
+s1.observe(null, error => {})

--- a/test/flow/sampledBy.js
+++ b/test/flow/sampledBy.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+import Kefir from '../../kefir'
+
+const source = Kefir.sequentially(0, [1, 2, 3, 4])
+const samples = Kefir.sequentially(0, ['one', 'one', 'one', 'one'])
+
+function test_sampledBy_noCombinator() {
+  const xs = source.sampledBy(samples)
+
+  xs.onValue((x: number) => {})
+}
+
+function test_sampledBy_withCombinator() {
+  const xs = source.sampledBy(samples, (n: number, s: string) => s)
+
+  // $ExpectError
+  source.sampledBy(samples, (s: string, n: number) => s)
+
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: number) => {})
+}

--- a/test/flow/scan.js
+++ b/test/flow/scan.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+import Kefir from '../../kefir'
+
+const source = Kefir.sequentially(10, [1, 2, 3, 4])
+
+function test_scan_noSeed() {
+  const xs = source.scan((x, y) => x - y)
+
+  xs.onValue((x: number) => {})
+}
+
+function test_scan_withSeed() {
+  // $ExpectError
+  source.scan((x, y) => x - y, 'foo')
+
+  const xs = source.scan((x, y) => x + String(y), 'foo')
+
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: number) => {})
+}

--- a/test/flow/toProperty.js
+++ b/test/flow/toProperty.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+import Kefir from '../../kefir'
+
+function test_toProperty() {
+  const xs = Kefir.sequentially(0, [1, 2, 3, 4])
+  const p = xs.toProperty()
+
+  p.onValue((x: number) => {})
+
+  // $ExpectError
+  p.onValue((x: string) => {})
+}
+
+function test_toProperty_getCurrent() {
+  const xs = Kefir.sequentially(0, [1, 2, 3, 4])
+  const p = xs.toProperty(() => 'foo')
+
+  p.onValue((x: number | string) => {})
+
+  // $ExpectError
+  p.onValue((x: number) => {})
+}

--- a/test/flow/vacuousObservables.js
+++ b/test/flow/vacuousObservables.js
@@ -1,0 +1,52 @@
+/*
+ * Some observables are guaranteed not to emit values or errors. For example,
+ * `Kefir.constant(x)` produces an observable that never emits errors. In those
+ * cases Kefir's type definitions use `empty` as a type parameter.
+ *
+ * @flow
+ */
+
+import Kefir from '../../kefir'
+
+function test_Constant() {
+  const c = Kefir.constant('foo')
+
+  c.onValue((x: string) => {})
+
+  // $ExpectError
+  c.onValue((x: number) => {})
+
+  // Error callbacks accept any argument type
+  c.onError((e: Error) => {})
+}
+
+function testConstantError() {
+  const c = Kefir.constantError(new Error('foo'))
+
+  // Value callbacks accept any argument type
+  c.onValue((x: string) => {})
+  c.onValue((x: number) => {})
+
+  c.onError((e: Error) => {})
+
+  // $ExpectError
+  c.onError((e: string) => {})
+}
+
+function testNever() {
+  const never = Kefir.never()
+
+  // Value and error callbacks accept any argument types
+  never.onValue((x: string) => {})
+  never.onValue((x: number) => {})
+  never.onError((e: Error) => {})
+
+  const merged = never.merge(Kefir.constant('foo'))
+
+  merged.onValue((x: string) => {})
+
+  // $ExpectError - the merged observable has `string` values, value callbacks must accept `string` arguments
+  merged.onValue((x: number) => {})
+
+  merged.onError((e: Error) => {})
+}

--- a/test/flow/zip.js
+++ b/test/flow/zip.js
@@ -27,6 +27,11 @@ function test_zip_method_withCombinator() {
 function test_zip_noCombinator() {
   const xs = Kefir.zip([as, bs, cs])
 
+  xs.onValue((x: [number, string, boolean]) => {})
+
+  // $ExpectError
+  xs.onValue((x: [boolean, string, number]) => {})
+
   xs.onValue((x: Array<number | string | boolean>) => {})
 
   // $ExpectError

--- a/test/flow/zip.js
+++ b/test/flow/zip.js
@@ -1,0 +1,40 @@
+/* @flow */
+
+import Kefir from '../../kefir'
+
+const as = Kefir.sequentially(0, [1, 2, 3, 4])
+const bs = Kefir.sequentially(0, ['foo', 'bar', 'baz'])
+const cs = Kefir.sequentially(0, [true, false, true])
+
+function test_zip_method_noCombinator() {
+  const xs = as.zip(bs)
+
+  xs.onValue((x: [number, string]) => {})
+
+  // $ExpectError
+  xs.onValue((x: Array<*>) => {})
+}
+
+function test_zip_method_withCombinator() {
+  const xs = as.zip(bs, (n, s) => `${n}: ${s}`)
+
+  xs.onValue((x: string) => {})
+
+  // $ExpectError
+  xs.onValue((x: [number, string]) => {})
+}
+
+function test_zip_noCombinator() {
+  const xs = Kefir.zip([as, bs, cs])
+
+  xs.onValue((x: Array<number | string | boolean>) => {})
+
+  // $ExpectError
+  xs.onValue((x: Array<number>) => {})
+}
+
+function test_zip_withCombinator() {
+  const xs = Kefir.zip([as, bs], (n, s) => `${n}: ${s}`)
+
+  xs.onValue((x: string) => {})
+}


### PR DESCRIPTION
The type definitions for Kefir are a joy to read! I learned some interesting new things - in particular the option to specify a default type for a type parameter (e.g. `declare class Observable<+V,+E=*>`), and the `$NonMaybeType<V>` utility type are features that I'm sure will come in handy.

I had a few ideas for improvements. Consider this pull request to be my suggestions.

## `empty` type parameter for vacuous observables

In cases where an observable is guaranteed to not produce either values or errors I changed the relevant type parameter from `*` to `empty`. I think that `empty` is the correct type, because it is effectively an assertion that something will not happen. And `empty` is an identity under the union operation, so certain operations will work out nicely.

For example I changed the type for `constant` to:

```js
constant<V>(value: V): Property<V,empty>;
```

That means that the type checker will allow `onError` callbacks with any type for the error value argument, which is safe because those callbacks should never be invoked. And the choice of argument type in those callbacks will not affect the type that Flow infers for error values later in the program.

If a constant property is combined with an observable that with an error type parameter of some type `E`, Flow will infer the error type of the resulting observable to be `empty | E`, which is equivalent to just `E`, which is what we want.

## more specific types for ESObservable interop

I'm planning on writing a library that consumes reactive streams, and I thought it would be nice to use the ESObservable interface so that I do not have to tie my library to one specific FRP library. I think that having a specific type for `toESObservable` will be handy.

## fix and verify types for overloaded methods and functions

I did some testing and found that overloaded signatures were not behaving as intended. I added a lot of tests, and made a bunch of changes to overloaded functions. One trick that fixed many cases was to put a dummy argument to the end of the argument list in some signatures to help Flow to select the correct overload branch. I used `$?: empty` for that purpose. For example:

```js
diff($?: empty): Observable<[V, V],E>;
diff<V2>(fn: (prev: V, next: V) => V2, $?: empty): Observable<V2,E>;
diff<V2,V3>(fn: (prev: V | V3, next: V) => V2, seed: V3): Observable<V2,E>;
diff<V3>(fn: null | void, seed: V3): Observable<[V | V3, V],E>;
```

The problem comes up when Flow encounters an invocation such as `obs.diff((x, y) => x - y)`. If the `$?: empty` argument were not present in the first signature, then the first two signatures would both be valid interpretations of that invocation. (This is because Flow permits an invocation to provide more arguments than are listed in the function signature.) Flow tends to pick the first signature; so the type of the resulting observable ends up as `Observable<[number, number], E>` when the type should be `Observable<number, E>` (assuming that the type of the input observable is `Observable<number, E>`.

Using the optional argument `$?: empty` removes the ambiguity. There is no possible argument that matches the type `empty`. So `$?: empty` effectively forces a signature to be applicable only in cases where the method is invoked with the exact number of arguments that are listed in the signature (not including the `$?: empty` argument.) I chose `$` for the parameter name is because it reminds me of the "end of input" token in a parser.

I did notice one use of the same trick in the existing signatures:

```js
observe(obs: Observer<V,E>, ...none: empty[]): Subscription;
```

I used `$?: empty` instead of `...none: empty[]` just because the former is a bit shorter.

It might be possible to remove the `$?: empty` trick in the future. I saw this in the changelog for Flow v0.46.0, which seems to imply that there might be changes to the way Flow interprets argument list lengths in an upcoming release:

> Starting in v0.47.0 we're going to complain when you call a function with more arguments than it expects. You can try it out in v0.46.0 with the .flowconfig option experimental.strict_call_arity=true. For more [check out this blog post](https://flow.org/blog/2017/05/07/Strict-Function-Call-Arity/)

I also expanded the definition of `combine` to use the newish `$ObjMap` utility type. The new type signature is enormous - but `$ObjMap` makes it possible to specify type rules very precisely when the inputs are given as objects with observables as property values.