### PR TITLE
Swtich === to <=

### DIFF
--- a/src/one-source/take-errors.js
+++ b/src/one-source/take-errors.js
@@ -11,7 +11,7 @@ const mixin = {
   _handleError(x) {
     this._n--
     this._emitError(x)
-    if (this._n === 0) {
+    if (this._n <= 0) {
       this._emitEnd()
     }
   },

--- a/src/one-source/take-errors.js
+++ b/src/one-source/take-errors.js
@@ -9,9 +9,12 @@ const mixin = {
   },
 
   _handleError(x) {
+    if (this._n === 0) {
+      return
+    }
     this._n--
     this._emitError(x)
-    if (this._n <= 0) {
+    if (this._n === 0) {
       this._emitEnd()
     }
   },

--- a/src/one-source/take.js
+++ b/src/one-source/take.js
@@ -9,9 +9,12 @@ const mixin = {
   },
 
   _handleValue(x) {
+    if (this._n === 0) {
+      return
+    }
     this._n--
     this._emitValue(x)
-    if (this._n <= 0) {
+    if (this._n === 0) {
       this._emitEnd()
     }
   },

--- a/src/one-source/take.js
+++ b/src/one-source/take.js
@@ -11,7 +11,7 @@ const mixin = {
   _handleValue(x) {
     this._n--
     this._emitValue(x)
-    if (this._n === 0) {
+    if (this._n <= 0) {
       this._emitEnd()
     }
   },

--- a/test/specs/take-errors.coffee
+++ b/test/specs/take-errors.coffee
@@ -1,4 +1,4 @@
-{stream, prop, send, Kefir} = require('../test-helpers.coffee')
+{stream, prop, send, Kefir, pool} = require('../test-helpers.coffee')
 
 
 
@@ -34,6 +34,14 @@ describe 'takeErrors', ->
       a = stream()
       expect(a.takeErrors(1)).toEmit [1, 2, 3, '<end>'], ->
         send(a, [1, 2, 3, '<end>'])
+
+    it 'should emit once on circular dependency', ->
+      a = pool()
+      b = a.takeErrors(1).mapErrors((x) -> x + 1)
+      a.plug(b)
+
+      expect(b).toEmit [{error: 2}, '<end>'], ->
+        send(a, [{error: 1}, {error: 2}, {error: 3}, {error: 4}, {error: 5}])
 
 
 

--- a/test/specs/take.coffee
+++ b/test/specs/take.coffee
@@ -1,4 +1,4 @@
-{stream, prop, send, Kefir} = require('../test-helpers.coffee')
+{stream, prop, send, Kefir, pool} = require('../test-helpers.coffee')
 
 
 
@@ -34,6 +34,13 @@ describe 'take', ->
       a = stream()
       expect(a.take(1)).errorsToFlow(a)
 
+    it 'should emit once on circular dependency', ->
+      a = pool()
+      b = a.take(1).map((x) -> x + 1)
+      a.plug(b)
+
+      expect(b).toEmit [2, '<end>'], ->
+        send(a, [1, 2, 3, 4, 5])
 
 
 

--- a/test/test-helpers.coffee
+++ b/test/test-helpers.coffee
@@ -70,6 +70,9 @@ exports.prop = ->
 exports.stream = ->
   new Kefir.Stream()
 
+exports.pool = ->
+  new Kefir.Pool()
+
 
 # This function changes timers' IDs so "simultaneous" timers are reversed
 # Also sets createdAt to 0 so closk.tick will sort by ID


### PR DESCRIPTION
If the application is structured such that it's possible to set up
a cyclical dependency, and a `take` stream emits a value that
synchronously results in another value being dispatched down
the `take` stream, the `this._n--` can get called twice, pushing it
down to -1 and thus never triggering `end`. This ensures the
stream will end after the value is emitted, even if another value
was emitted in the meantime.