### PR TITLE
Add failing test case for #249

### DIFF
--- a/test/specs/pool.js
+++ b/test/specs/pool.js
@@ -80,6 +80,19 @@ describe('pool', () => {
     })
   })
 
+  it('should deactivate self in circular dependency', () => {
+    const pool = Kefir.pool()
+    pool.plug(pool.map(x => x))
+
+    const sub = pool.observe()
+
+    expect(pool).toBeActive()
+
+    sub.unsubscribe()
+
+    expect(pool).not.toBeActive()
+  })
+
   it('errors should flow', () => {
     const a = stream()
     const b = prop()


### PR DESCRIPTION
Subscribing to a circular dep should cause everything to
deactivate but doesn't.

I don't have a solution to this yet, but if anyone has ideas why this might be happening, we at least have a test case we can use to verify the solution.